### PR TITLE
Adjust Automatic Date Updates to Run on Save

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -177,8 +177,7 @@ export async function activate(context: vscode.ExtensionContext) {
 	triggerShowDraftStatus();
 
 	// Listener for file edit changes
-	editDebounce = debounceCallback();
-	subscriptions.push(vscode.workspace.onDidChangeTextDocument(triggerFileChange));
+	subscriptions.push(vscode.workspace.onWillSaveTextDocument(handleAutoDateUpdate));
 
 	// Listener for file saves
 	subscriptions.push(vscode.workspace.onDidSaveTextDocument((doc: vscode.TextDocument) => {
@@ -231,8 +230,8 @@ export async function activate(context: vscode.ExtensionContext) {
 
 export function deactivate() {}
 
-const triggerFileChange = (e: vscode.TextDocumentChangeEvent) => {
-	editDebounce(() => Article.autoUpdate(e), 1000);
+const handleAutoDateUpdate = (e: vscode.TextDocumentWillSaveEvent) => {
+	Article.autoUpdate(e);
 };
 
 const triggerShowDraftStatus = () => {

--- a/src/helpers/ArticleHelper.ts
+++ b/src/helpers/ArticleHelper.ts
@@ -27,8 +27,17 @@ export class ArticleHelper {
    * @param editor 
    */
   public static getFrontMatter(editor: vscode.TextEditor) {
-    const fileContents = editor.document.getText();  
-    return ArticleHelper.parseFile(fileContents, editor.document.fileName);
+    return ArticleHelper.getFrontMatterFromDocument(editor.document);
+  }
+
+  /**
+   * Get the contents of the specified document
+   * 
+   * @param document The document to parse.
+   */
+  public static getFrontMatterFromDocument(document: vscode.TextDocument) {
+    const fileContents = document.getText();
+    return ArticleHelper.parseFile(fileContents, document.fileName);
   }
 
   /**
@@ -47,6 +56,18 @@ export class ArticleHelper {
    * @param article 
    */
   public static async update(editor: vscode.TextEditor, article: matter.GrayMatterFile<string>) {
+    const update = this.generateUpdate(editor.document, article);
+
+    await editor.edit(builder => builder.replace(update.range, update.newText));
+  }
+
+  /**
+   * Generate the update to be applied to the article.
+   * @param article 
+   */
+  public static generateUpdate(document: vscode.TextDocument, article: matter.GrayMatterFile<string>): vscode.TextEdit {
+    const nrOfLines = document.lineCount as number;
+    const range = new vscode.Range(new vscode.Position(0, 0), new vscode.Position(nrOfLines, 0));
     const removeQuotes = Settings.get(SETTING_REMOVE_QUOTES) as string[];
     const commaSeparated = Settings.get<string[]>(SETTING_COMMA_SEPARATED_FIELDS);
     
@@ -68,8 +89,7 @@ export class ArticleHelper {
       }
     }
 
-    const nrOfLines = editor.document.lineCount as number;
-    await editor.edit(builder => builder.replace(new vscode.Range(new vscode.Position(0, 0), new vscode.Position(nrOfLines, 0)), newMarkdown));
+    return vscode.TextEdit.replace(range, newMarkdown);
   }
 
   /**
@@ -109,12 +129,12 @@ export class ArticleHelper {
   /**
    * Checks if the current file is a markdown file
    */ 
-  public static isMarkdownFile() {
+  public static isMarkdownFile(document: vscode.TextDocument | undefined | null = null) {
     const supportedLanguages = ["markdown", "mdx"];
     const supportedFileExtensions = [".md", ".mdx"];
-    const document = vscode.window.activeTextEditor?.document;
     const languageId = document?.languageId?.toLowerCase();
     const isSupportedLanguage =  languageId && supportedLanguages.includes(languageId);
+    document ??= vscode.window.activeTextEditor?.document;
 
     /**
      * It's possible that the file is a file type we support but the user hasn't installed


### PR DESCRIPTION
# Description
Per https://github.com/estruyf/vscode-front-matter/issues/221 , on-change events can be triggered twice due to the implementation of the change detection logic.

This is caused by `gray-matter` appending a newline character when rendering front matter content when the original file doesn't have a newline character, per: https://github.com/jonschlinkert/gray-matter/blob/master/lib/stringify.js#L51 . This is out of user control, which means that in all cases the extension will double-update the last modified property.

The effort here removes the change detection logic altogether, instead using the `onWillSaveTextDocument` event as a proxy for when we should automatically update the last modified date. This is similar to how a file system might update the last modified property of the file on the file system, which makes sense.

# Testing
* I validated that the new logic updates the last modified property as expected on save, when the auto-update setting is enabled.
* I validated that the new logic continues to not update the last modified property as expected when the setting is disabled.
* I validated that other features that update the article continue to function (like editing the title or description in the document)