### PR TITLE
Sync button now adds and commits deleted files with git

### DIFF
--- a/src/listeners/general/GitListener.ts
+++ b/src/listeners/general/GitListener.ts
@@ -105,6 +105,9 @@ export class GitListener {
     for (const file of status.modified) {
       await git.add(file);
     }
+    for (const file of status.deleted) {
+      await git.add(file);
+    }
 
     await git.commit(commitMsg || "Synced by Front Matter")
 


### PR DESCRIPTION
# Sync button now adds and commits deleted files with git

## Description

This PR only affects the ```GitListener.ts``` file. In there I've added another for loop that iterates through the deleted files contained in the status object, returned by ```git.status()```, along with the other two existing loops that add the ```not_added``` and ```modified``` files.

## Related Issue and Motivation

[This](https://github.com/estruyf/vscode-front-matter/issues/465) is the related issue, regarding the absence of deleted files when using Front Matter to commit with git.

## How Has This Been Tested

This should be a pretty painless modification since no code was deleted and the lines added are concise and clear, adhering semantically to their surroundings.

For reference, I've tested this PR on a Windows 10 21H2 machine, with VSCode version 1.71.0.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)