### PR TITLE
Issue/#504

### DIFF
--- a/package.json
+++ b/package.json
@@ -1254,6 +1254,11 @@
                 "type": "string",
                 "default": "",
                 "description": "An optional post script that can be used after new content creation."
+              },
+              "defaultFileName": {
+                "type": "string",
+                "default": "index",
+                "description": "Default file name to use when creating new content."
               }
             },
             "additionalProperties": false,

--- a/src/helpers/ArticleHelper.ts
+++ b/src/helpers/ArticleHelper.ts
@@ -359,7 +359,7 @@ export class ArticleHelper {
         return;
       } else {
         await mkdirAsync(newFolder);
-        newFilePath = join(newFolder, `${contentType.defaultFileName ?? `index`}.${fileExtension || contentType.fileType || fileType}`);
+        newFilePath = join(newFolder, `${sanitize(contentType.defaultFileName ?? `index`) }.${fileExtension || contentType.fileType || fileType}`);
       }
     } else {
       let newFileName = `${sanitizedName}.${fileExtension || contentType?.fileType || fileType}`;

--- a/src/helpers/ArticleHelper.ts
+++ b/src/helpers/ArticleHelper.ts
@@ -359,7 +359,7 @@ export class ArticleHelper {
         return;
       } else {
         await mkdirAsync(newFolder);
-        newFilePath = join(newFolder, `index.${fileExtension || contentType.fileType || fileType}`);
+        newFilePath = join(newFolder, `${contentType.defaultFileName ?? `index`}.${fileExtension || contentType.fileType || fileType}`);
       }
     } else {
       let newFileName = `${sanitizedName}.${fileExtension || contentType?.fileType || fileType}`;

--- a/src/models/PanelSettings.ts
+++ b/src/models/PanelSettings.ts
@@ -47,6 +47,7 @@ export interface ContentType {
   fileType?: "md" | "mdx" | string;
   previewPath?: string | null;
   pageBundle?: boolean;
+  defaultFileName?: string;
   template?: string;
   postScript?: string;
 }

--- a/src/panelWebView/components/FileItem.tsx
+++ b/src/panelWebView/components/FileItem.tsx
@@ -18,8 +18,16 @@ const FileItem: React.FunctionComponent<IFileItemProps> = ({ name, folderName, p
     Messenger.send(CommandToCode.openInEditor, path);
   };
 
+  /*  
+      File names which would not give any info about the content.
+      by themselves, e.g.: index | +page | etc…
+      Ideally we should have access to the `defaultFileName`
+      property of the contentType here to check.
+  */
+  const vagueFileNamesList = ['index', '+page']
+
   const itemName = useMemo(() => {
-    if (folderName && name.includes("index.")) {
+    if (folderName && vagueFileNamesList.some(vagueFileName => name.includes(vagueFileName + '.'))) {
       return folderName;
     }
 


### PR DESCRIPTION
# PR Details

- Introduces the optional `defaultFileName` property for content types. 
- Fixes `Recently Modified` panel view to fallback to folder name on SvelteKit.

## Description

```json
  "frontMatter.content.pageFolders": [
    {
      "title": "Projects",
      "path": "[[workspace]]/src/routes/projects/", <---
      "filePrefix": "",
      "contentTypes": [
        "project"
      ],
      "previewPath": "'projects/'"
    }
  ],
  "frontMatter.taxonomy.contentTypes": [
    {
      "name": "project",
      "pageBundle": true,
      "defaultFileName": "+page", <---
      "fields": [
        {
          "title": "Title",
          "name": "title",
          "type": "string",
          "single": true
        }
        …
    }
]
```

FM UI -> Create content -> with title: `new title` now creates:
`/src/routes/projects/new-title/+page.md`


## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/estruyf/vscode-front-matter/issues/504

## Motivation and Context

SvelteKit does not consider the `index` named markdown file to represent a page, instead it dictates the file name `+page`. This makes creating new content using the FM UI a bit problematic because the created index file should be renamed every time.

Following that I discovered that `Recently Modified` field which lists the files also relies on the keyword `index` in order to fallback to the folder name. To keep the same functionality (display folder name instead of file name) I provided a hardcoded solution which addresses my use case for now.

before             |  after
:-------------------------:|:-------------------------:
|![before](https://user-images.githubusercontent.com/1499672/218219781-4de6c246-e5f1-452c-8c38-9cd9e81d5e9e.png)  |  ![after](https://user-images.githubusercontent.com/1499672/218219787-6e285641-48ac-43c9-b783-316905586eef.png)


## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
