### PR TITLE
fix: typo

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
       }]
     },
     "configuration": {
-      "$id": "#gobalconfiguration",
+      "$id": "#globalconfiguration",
       "title": "Front Matter: use frontmatter.json for shared team settings",
       "type": "object",
       "properties": {
@@ -114,7 +114,7 @@
                 "markdownDescription": "Specify if this project is the default project to load."
               },
               "configuration": {
-                "$ref": "#gobalconfiguration"
+                "$ref": "#globalconfiguration"
               }
             }
           }


### PR DESCRIPTION

# PR Details

This should fix the error:

```sh
$ref 'gobalconfiguration' in 'vscode://schemas/settings/configurationDefaults' can not be resolved.
```

## Description

There is an vscode issue when viewing `package.json`


## Related Issue

https://github.com/estruyf/vscode-front-matter/issues/575

## How Has This Been Tested

Did not test. Just fixing the typo.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
