### PR TITLE
fix: correct link for data files view

### DIFF
--- a/src/dashboardWebView/components/DataView/DataView.tsx
+++ b/src/dashboardWebView/components/DataView/DataView.tsx
@@ -299,7 +299,7 @@ export const DataView: React.FunctionComponent<IDataViewProps> = (
             <p className="text-xl mt-4">
               <a
                 className={getColors(`text-teal-700 hover:text-teal-900`, `text-[var(--frontmatter-link)] hover:text-[var(--frontmatter-link-hover)]`)}
-                href={`https://frontmatter.codes/docs/dashboard#data-files-view`}
+                href={`https://frontmatter.codes/docs/datafiles-view`}
                 title={`Read more to get started using data files`}
               >
                 Read more to get started using data files


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

The link to data files view is incorrect.

Right link : https://frontmatter.codes/docs/datafiles-view

Current link: https://frontmatter.codes/docs/dashboard#data-files-view

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
