### PR TITLE
fix: typo

### DIFF
--- a/l10n/bundle.l10n.json
+++ b/l10n/bundle.l10n.json
@@ -144,7 +144,7 @@
   "dashboard.dataView.dataView.selectDataFolder": "Select data folder",
   "dashboard.dataView.dataView.closeSelectedDataFile": "Close data file",
 
-  "dashboard.dataView.emptyView.heading": "Select your date type first",
+  "dashboard.dataView.emptyView.heading": "Select your data type first",
   "dashboard.dataView.emptyView.heading.create": "Start by creating a new data file",
 
   "dashboard.dataView.sortableItem.editButton.title": "Edit \"{0}\"",


### PR DESCRIPTION
# PR Details

Changes data view intro from `date` to `data`

## Related Issue

Fixes #860 

## Types of changes

- [x] Typo
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
