### PR TITLE
Add `sameContentLocale` option to filter content relationship suggestions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1543,6 +1543,11 @@
                       "default": "path",
                       "description": "%setting.frontMatter.taxonomy.contentTypes.items.properties.fields.items.properties.contentTypeValue.description%"
                     },
+                    "sameContentLocale": {
+                      "type": "boolean",
+                      "default": true,
+                      "description": "%setting.frontMatter.taxonomy.contentTypes.items.properties.fields.items.properties.sameContentLocale.description%"
+                    },
                     "when": {
                       "type": "object",
                       "description": "%setting.frontMatter.taxonomy.contentTypes.items.properties.fields.items.properties.when.description%",

--- a/package.nls.json
+++ b/package.nls.json
@@ -228,6 +228,7 @@
   "setting.frontMatter.taxonomy.contentTypes.items.properties.fields.items.properties.required.description": "Specify if the field is required",
   "setting.frontMatter.taxonomy.contentTypes.items.properties.fields.items.properties.contentTypeName.description": "Specify the content type name to filter content for the contentRelationship field",
   "setting.frontMatter.taxonomy.contentTypes.items.properties.fields.items.properties.contentTypeValue.description": "Specify the value to insert for the contentRelationship field",
+  "setting.frontMatter.taxonomy.contentTypes.items.properties.fields.items.properties.sameContentLocale.description": "Specify if you only want to show the content with the same locale",
   "setting.frontMatter.taxonomy.contentTypes.items.properties.fields.items.properties.when.description": "Specify the conditions to show the field",
   "setting.frontMatter.taxonomy.contentTypes.items.properties.fields.items.properties.when.properties.fieldRef.description": "The field ID to use",
   "setting.frontMatter.taxonomy.contentTypes.items.properties.fields.items.properties.when.properties.operator.description": "The operator to use",

--- a/src/listeners/dashboard/PagesListener.ts
+++ b/src/listeners/dashboard/PagesListener.ts
@@ -257,7 +257,7 @@ export class PagesListener extends BaseListener {
    */
   private static async createSearchIndex(pages: Page[]) {
     const pagesIndex = Fuse.createIndex(
-      ['title', 'slug', 'description', 'fmBody', 'type', 'fmContentType'],
+      ['title', 'slug', 'description', 'fmBody', 'type', 'fmContentType', 'fmLocale.locale'],
       pages
     );
     await Extension.getInstance().setState(

--- a/src/listeners/panel/FieldsListener.ts
+++ b/src/listeners/panel/FieldsListener.ts
@@ -36,7 +36,8 @@ export class FieldsListener extends BaseListener {
 
     PagesListener.getPagesData(false, async (pages) => {
       const fuseOptions: Fuse.IFuseOptions<Page> = {
-        keys: [{ name: 'fmContentType', weight: 1 }]
+        keys: [{ name: 'fmContentType', weight: 1 }],
+        threshold: 0,
       };
 
       const pagesIndex = await Extension.getInstance().getState<Fuse.FuseIndex<Page>>(

--- a/src/models/PanelSettings.ts
+++ b/src/models/PanelSettings.ts
@@ -135,6 +135,7 @@ export interface Field {
   // Content relationship
   contentTypeName?: string;
   contentTypeValue?: 'path' | 'slug';
+  sameContentLocale?: boolean;
 
   // Custom field
   customType?: string;

--- a/src/panelWebView/components/Fields/ContentTypeRelationshipField.tsx
+++ b/src/panelWebView/components/Fields/ContentTypeRelationshipField.tsx
@@ -219,6 +219,7 @@ export const ContentTypeRelationshipField: React.FunctionComponent<IContentTypeR
                         value={getValue(choice, contentTypeValue)}
                         className={({ active }) => `py-[var(--input-padding-vertical)] px-[var(--input-padding-horizontal)] list-none cursor-pointer hover:text-[var(--vscode-button-foreground)] hover:bg-[var(--vscode-button-hoverBackground)] ${active ? "text-[var(--vscode-button-foreground)] bg-[var(--vscode-button-hoverBackground)] " : ""}`}>
                         {choice.title}
+                        <div className='text-xs opacity-60 mt-0.5'>{choice.slug}</div>
                       </Combobox.Option>
                     ))}
 

--- a/src/panelWebView/components/Fields/WrapperField.tsx
+++ b/src/panelWebView/components/Fields/WrapperField.tsx
@@ -497,6 +497,7 @@ export const WrapperField: React.FunctionComponent<IWrapperFieldProps> = ({
           required={!!field.required}
           contentTypeName={field.contentTypeName}
           contentTypeValue={field.contentTypeValue}
+          sameContentLocale={field.sameContentLocale}
           multiSelect={field.multiple}
           onChange={onFieldChange}
         />


### PR DESCRIPTION
Closes #851.

### Changes

- [ ] Fixes issue where content relationship suggestions (combobox options) where incorrectly filtered by `fmContentType` (cause: fuse threshold)
- [ ] Minor display improvement: Show slug as subtitle in combobox option
- [ ] Add option `sameContentLocale` (defaults to `true`*) that, if set, filters content relationship suggestions by the active locale of the currently edited file. 

*Happy to discuss the default here as it changes the current behavior. I think the scenarios where you actually add relations to files with _different_ locales are very uncommon.

### Screenshot

![CleanShot 2024-10-07 at 10 56 21@2x](https://github.com/user-attachments/assets/176b90fb-5765-4889-90e5-66464f63c635)
