### PR TITLE
feat: add smart rename to sync filename with front matter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### 🎨 Enhancements
 
+- [#545](https://github.com/estruyf/vscode-front-matter/issues/545): Add smart rename action to sync filename with front matter data
 - [#937](https://github.com/estruyf/vscode-front-matter/issues/937): Dashboard "Structure" view for documentation sites *WIP*
 - [#965](https://github.com/estruyf/vscode-front-matter/issues/965): Added SEO support for the keyword in the first paragraph
 - [#973](https://github.com/estruyf/vscode-front-matter/issues/973): Support for number fields in the snippets

--- a/l10n/bundle.l10n.json
+++ b/l10n/bundle.l10n.json
@@ -524,6 +524,8 @@
 
   "panel.slugAction.title": "Optimize slug",
 
+  "panel.smartRenameAction.title": "Smart rename",
+
   "panel.spinner.loading": "Loading...",
 
   "panel.startServerbutton.start": "Start server",
@@ -549,6 +551,13 @@
   "commands.article.rename.fileExists.error": "A file with the name \"{0}\" already exists",
   "commands.article.rename.fileName.title": "Rename: {0}",
   "commands.article.rename.fileName.prompt": "File name",
+
+  "commands.article.smartRename.alreadyInSync": "The filename is already in sync with the front matter",
+  "commands.article.smartRename.success": "File renamed from \"{0}\" to \"{1}\"",
+  "commands.article.smartRename.unableToGenerate": "Unable to generate a new filename from the front matter",
+  "commands.article.smartRename.fileExists.error": "A file with the name \"{0}\" already exists",
+
+  "dashboard.contents.contentActions.menuItem.smartRename": "Smart rename",
 
   "commands.cache.cleared": "Cache cleared",
 

--- a/package.json
+++ b/package.json
@@ -2856,7 +2856,7 @@
     ]
   },
   "scripts": {
-    "dev:ext": "npm run clean && npm run localization:generate && npm-run-all --parallel watch:*",
+    "dev": "npm run clean && npm run localization:generate && npm-run-all --parallel watch:*",
     "vscode:prepublish": "npm run clean && npm run localization:generate && npm-run-all --parallel prod:*",
     "build:ext": "npm run clean && npm-run-all --parallel dev:build:*",
     "watch:ext": "webpack --mode development --watch --config ./webpack/extension.config.js",

--- a/src/dashboardWebView/DashboardMessage.ts
+++ b/src/dashboardWebView/DashboardMessage.ts
@@ -32,6 +32,7 @@ export enum DashboardMessage {
   pinItem = 'pinItem',
   unpinItem = 'unpinItem',
   rename = 'rename',
+  smartRename = 'smartRename',
   moveFile = 'moveFile',
 
   // Media Dashboard

--- a/src/dashboardWebView/components/Contents/ContentActions.tsx
+++ b/src/dashboardWebView/components/Contents/ContentActions.tsx
@@ -74,12 +74,12 @@ export const ContentActions: React.FunctionComponent<IContentActionsProps> = ({
   const onRename = React.useCallback((e: React.MouseEvent<HTMLButtonElement | HTMLDivElement, MouseEvent>) => {
     e.stopPropagation();
     messageHandler.send(DashboardMessage.rename, path);
-  }, [path])
+  }, [path]);
 
   const onSmartRename = React.useCallback((e: React.MouseEvent<HTMLButtonElement | HTMLDivElement, MouseEvent>) => {
     e.stopPropagation();
     messageHandler.send(DashboardMessage.smartRename, path);
-  }, [path])
+  }, [path]);
 
   const onOpenWebsite = React.useCallback((e: React.MouseEvent<HTMLButtonElement | HTMLDivElement, MouseEvent>) => {
     e.stopPropagation();

--- a/src/dashboardWebView/components/Contents/ContentActions.tsx
+++ b/src/dashboardWebView/components/Contents/ContentActions.tsx
@@ -5,7 +5,8 @@ import {
   TrashIcon,
   LanguageIcon,
   EllipsisHorizontalIcon,
-  ArrowRightCircleIcon
+  ArrowRightCircleIcon,
+  ArrowPathIcon
 } from '@heroicons/react/24/outline';
 import * as React from 'react';
 import { CustomScript, I18nConfig } from '../../../models';
@@ -75,6 +76,11 @@ export const ContentActions: React.FunctionComponent<IContentActionsProps> = ({
     messageHandler.send(DashboardMessage.rename, path);
   }, [path])
 
+  const onSmartRename = React.useCallback((e: React.MouseEvent<HTMLButtonElement | HTMLDivElement, MouseEvent>) => {
+    e.stopPropagation();
+    messageHandler.send(DashboardMessage.smartRename, path);
+  }, [path])
+
   const onOpenWebsite = React.useCallback((e: React.MouseEvent<HTMLButtonElement | HTMLDivElement, MouseEvent>) => {
     e.stopPropagation();
     openOnWebsite(settings?.websiteUrl, path);
@@ -142,6 +148,11 @@ export const ContentActions: React.FunctionComponent<IContentActionsProps> = ({
                 <DropdownMenuItem onClick={onRename}>
                   <RenameIcon className={`mr-2 h-4 w-4`} aria-hidden={true} />
                   <span>{l10n.t(LocalizationKey.commonRename)}</span>
+                </DropdownMenuItem>
+
+                <DropdownMenuItem onClick={onSmartRename}>
+                  <ArrowPathIcon className={`mr-2 h-4 w-4`} aria-hidden={true} />
+                  <span>{l10n.t(LocalizationKey.dashboardContentsContentActionsMenuItemSmartRename)}</span>
                 </DropdownMenuItem>
 
                 {

--- a/src/helpers/ArticleHelper.ts
+++ b/src/helpers/ArticleHelper.ts
@@ -237,6 +237,146 @@ export class ArticleHelper {
   }
 
   /**
+   * Smart rename a file based on its front matter title and publish date.
+   * Regenerates the expected filename using the same logic as content creation.
+   * @param filePath - The path of the file to be renamed.
+   */
+  public static async smartRename(filePath?: string) {
+    if (!filePath) {
+      const editor = vscode.window.activeTextEditor;
+      if (!editor) {
+        return;
+      }
+      filePath = editor.document.uri.fsPath;
+    }
+
+    filePath = parseWinPath(filePath);
+    const fileUri = Uri.file(filePath);
+
+    const article = await ArticleHelper.getFrontMatterByPath(filePath);
+    if (!article || !article.data) {
+      Notifications.error(
+        l10n.t(LocalizationKey.commandsArticleRenameFileNotExistsError)
+      );
+      return;
+    }
+
+    const titleField = getTitleField();
+    const title: string = article.data[titleField];
+    if (!title) {
+      Notifications.warning(
+        l10n.t(LocalizationKey.commandsArticleSmartRenameUnableToGenerate)
+      );
+      return;
+    }
+
+    const contentType = await ArticleHelper.getContentType(article);
+    const articleDate = await ArticleHelper.getDate(article);
+
+    let filePrefix = Settings.get<string>(SETTING_TEMPLATES_PREFIX);
+    filePrefix = await ArticleHelper.getFilePrefix(
+      filePrefix,
+      filePath,
+      contentType,
+      title,
+      articleDate
+    );
+
+    const sanitizedName = ArticleHelper.sanitize(title);
+    const parsed = parseFile(filePath);
+    const folderPath = dirname(fileUri.fsPath);
+
+    let newFileName: string;
+    if (contentType?.pageBundle) {
+      // For page bundles, the folder name should be updated
+      if (filePrefix && typeof filePrefix === 'string') {
+        if (filePrefix.endsWith('/')) {
+          newFileName = `${filePrefix}${sanitizedName}`;
+        } else {
+          newFileName = `${filePrefix}-${sanitizedName}`;
+        }
+      } else {
+        newFileName = sanitizedName;
+      }
+
+      const parentFolder = dirname(folderPath);
+      const currentFolderName = parseFile(folderPath).base;
+
+      if (currentFolderName === newFileName) {
+        Notifications.info(
+          l10n.t(LocalizationKey.commandsArticleSmartRenameAlreadyInSync)
+        );
+        return;
+      }
+
+      const newFolderPath = join(parentFolder, newFileName);
+      if (await existsAsync(newFolderPath)) {
+        Notifications.error(
+          l10n.t(LocalizationKey.commandsArticleSmartRenameFileExistsError, newFileName)
+        );
+        return;
+      }
+
+      await workspace.fs.rename(Uri.file(folderPath), Uri.file(newFolderPath), {
+        overwrite: false
+      });
+
+      Notifications.info(
+        l10n.t(
+          LocalizationKey.commandsArticleSmartRenameSuccess,
+          currentFolderName,
+          newFileName
+        )
+      );
+    } else {
+      // For regular files, rename the file
+      let newFileBase = `${sanitizedName}${parsed.ext}`;
+      if (filePrefix && typeof filePrefix === 'string') {
+        if (filePrefix.endsWith('/')) {
+          newFileBase = `${filePrefix}${newFileBase}`;
+        } else {
+          newFileBase = `${filePrefix}-${newFileBase}`;
+        }
+      }
+
+      if (parsed.base === newFileBase) {
+        Notifications.info(
+          l10n.t(LocalizationKey.commandsArticleSmartRenameAlreadyInSync)
+        );
+        return;
+      }
+
+      const newFileUri = Uri.joinPath(Uri.file(folderPath), newFileBase);
+      if (await existsAsync(newFileUri.fsPath)) {
+        Notifications.error(
+          l10n.t(LocalizationKey.commandsArticleSmartRenameFileExistsError, newFileBase)
+        );
+        return;
+      }
+
+      // Close the document if it's open in an editor before renaming
+      const openEditors = vscode.window.visibleTextEditors.filter(
+        (e) => parseWinPath(e.document.uri.fsPath) === filePath
+      );
+      for (const editor of openEditors) {
+        await editor.document.save();
+      }
+
+      await workspace.fs.rename(fileUri, newFileUri, {
+        overwrite: false
+      });
+
+      Notifications.info(
+        l10n.t(
+          LocalizationKey.commandsArticleSmartRenameSuccess,
+          parsed.base,
+          newFileBase
+        )
+      );
+    }
+  }
+
+  /**
    * Generate the update to be applied to the article.
    * @param article
    */

--- a/src/listeners/dashboard/PagesListener.ts
+++ b/src/listeners/dashboard/PagesListener.ts
@@ -74,6 +74,9 @@ export class PagesListener extends BaseListener {
       case DashboardMessage.moveFile:
         await this.moveFile(msg.payload);
         break;
+      case DashboardMessage.smartRename:
+        ArticleHelper.smartRename(msg.payload);
+        break;
     }
   }
 

--- a/src/listeners/panel/ArticleListener.ts
+++ b/src/listeners/panel/ArticleListener.ts
@@ -25,6 +25,9 @@ export class ArticleListener extends BaseListener {
       case CommandToCode.publish:
         Article.toggleDraft();
         break;
+      case CommandToCode.smartRename:
+        ArticleHelper.smartRename();
+        break;
     }
   }
 

--- a/src/localization/localization.enum.ts
+++ b/src/localization/localization.enum.ts
@@ -1697,6 +1697,10 @@ export enum LocalizationKey {
    */
   panelSlugActionTitle = 'panel.slugAction.title',
   /**
+   * Smart rename
+   */
+  panelSmartRenameActionTitle = 'panel.smartRenameAction.title',
+  /**
    * Loading...
    */
   panelSpinnerLoading = 'panel.spinner.loading',
@@ -1772,6 +1776,26 @@ export enum LocalizationKey {
    * File name
    */
   commandsArticleRenameFileNamePrompt = 'commands.article.rename.fileName.prompt',
+  /**
+   * The filename is already in sync with the front matter
+   */
+  commandsArticleSmartRenameAlreadyInSync = 'commands.article.smartRename.alreadyInSync',
+  /**
+   * File renamed from "{0}" to "{1}"
+   */
+  commandsArticleSmartRenameSuccess = 'commands.article.smartRename.success',
+  /**
+   * Unable to generate a new filename from the front matter
+   */
+  commandsArticleSmartRenameUnableToGenerate = 'commands.article.smartRename.unableToGenerate',
+  /**
+   * A file with the name "{0}" already exists
+   */
+  commandsArticleSmartRenameFileExistsError = 'commands.article.smartRename.fileExists.error',
+  /**
+   * Smart rename
+   */
+  dashboardContentsContentActionsMenuItemSmartRename = 'dashboard.contents.contentActions.menuItem.smartRename',
   /**
    * Cache cleared
    */

--- a/src/models/PanelSettings.ts
+++ b/src/models/PanelSettings.ts
@@ -38,6 +38,7 @@ export type PanelAction =
   | 'openDashboard'
   | 'createContent'
   | 'optimizeSlug'
+  | 'smartRename'
   | 'preview'
   | 'openOnWebsite'
   | 'startStopServer'

--- a/src/panelWebView/CommandToCode.ts
+++ b/src/panelWebView/CommandToCode.ts
@@ -48,5 +48,6 @@ export enum CommandToCode {
   searchByType = 'search-by-type',
   processMediaData = 'process-media-data',
   isServerStarted = 'is-server-started',
-  runFieldAction = 'run-field-action'
+  runFieldAction = 'run-field-action',
+  smartRename = 'smart-rename'
 }

--- a/src/panelWebView/components/Actions.tsx
+++ b/src/panelWebView/components/Actions.tsx
@@ -4,6 +4,7 @@ import { Collapsible } from './Collapsible';
 import { CustomScript } from './CustomScript';
 import { Preview } from './Preview';
 import { SlugAction } from './SlugAction';
+import { SmartRenameAction } from './SmartRenameAction';
 import { StartServerButton } from './StartServerButton';
 import * as l10n from '@vscode/l10n';
 import { LocalizationKey } from '../../localization';
@@ -50,6 +51,10 @@ const Actions: React.FunctionComponent<IActionsProps> = ({
 
     if (metadata?.title && !disableActions.includes(`optimizeSlug`)) {
       allActions.push(<SlugAction key="optimizeSlug" />);
+    }
+
+    if (metadata?.title && !disableActions.includes(`smartRename`)) {
+      allActions.push(<SmartRenameAction key="smartRename" />);
     }
 
     if (settings?.preview?.host && !disableActions.includes(`preview`)) {

--- a/src/panelWebView/components/SmartRenameAction.tsx
+++ b/src/panelWebView/components/SmartRenameAction.tsx
@@ -1,0 +1,25 @@
+import { Messenger } from '@estruyf/vscode/dist/client';
+import * as React from 'react';
+import { CommandToCode } from '../CommandToCode';
+import { ActionButton } from './ActionButton';
+import * as l10n from '@vscode/l10n';
+import { LocalizationKey } from '../../localization';
+
+export interface ISmartRenameActionProps { }
+
+const SmartRenameAction: React.FunctionComponent<
+  ISmartRenameActionProps
+> = () => {
+  const smartRename = () => {
+    Messenger.send(CommandToCode.smartRename);
+  };
+
+  return (
+    <ActionButton onClick={smartRename} title={l10n.t(LocalizationKey.panelSmartRenameActionTitle)}>
+      {l10n.t(LocalizationKey.panelSmartRenameActionTitle)}
+    </ActionButton>
+  );
+};
+
+SmartRenameAction.displayName = 'SmartRenameAction';
+export { SmartRenameAction };


### PR DESCRIPTION
# PR Details

## Description

Adds a "Smart Rename" feature that regenerates the filename from current front matter values (title and publish date) using the same logic as content creation. When a user changes the title or publish date in front matter after creating a file, the filename no longer matches. This feature lets them re-sync the filename with a single action.

**How it works:**
- Reads the current title and publish date (from the `isPublishDate` field) from front matter
- Generates the expected filename using the existing `ArticleHelper.sanitize()` + `ArticleHelper.getFilePrefix()` pipeline — the same logic used during content creation
- Compares with the current filename and renames if different
- Supports page bundles (renames the folder) and detects file collisions
- Available as a button in the panel Actions section and in the dashboard content card dropdown menu
- Can be disabled via `smartRename` in `disabledActions`

## Related Issue

Closes #545

## Motivation and Context

Content creators frequently change titles and publish dates after creating a file. The filename (which may include a date prefix like `yyyy-MM-dd` and a slugified title) gets out of sync, making it hard to manage and sort content. Users currently have to manually rename files in the file explorer, which is error-prone and tedious.

## How Has This Been Tested

- All three webpack builds (extension, panel, dashboard) compile successfully with no new errors
- Verified the feature integrates with the existing file naming pipeline (`sanitize`, `getFilePrefix`, date/time placeholders)

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)